### PR TITLE
feat: add browser visual tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,5 @@ jobs:
       - run: npm run lint
       - run: npm run typecheck
       - run: npm test
+      - run: npx playwright install --with-deps
+      - run: npm run test:browser

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ dist-ssr
 
 # Generated assets
 # (handled by dist ignore above)
+
+# Playwright artifacts
+**/__screenshots__/*-diff.png
+**/__screenshots__/*-expected.png
+**/__screenshots__/*-actual.png

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@dice-roller/rpg-dice-roller": "^5.5.1",
         "@eslint/js": "^9.30.1",
+        "@playwright/test": "^1.54.2",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -3252,6 +3253,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -7904,6 +7921,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint:js": "eslint .",
     "lint:css": "stylelint \"src/**/*.{css,scss}\"",
     "preview": "vite preview",
-    "test": "vitest run --environment jsdom",
+    "test": "vitest run --environment jsdom --exclude=\"test/visual/**\"",
+    "test:browser": "playwright test test/visual --browser=webkit",
     "typecheck": "tsc --noEmit",
     "update-submodules": "git submodule update --init --recursive && git submodule sync"
   },
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@dice-roller/rpg-dice-roller": "^5.5.1",
     "@eslint/js": "^9.30.1",
+    "@playwright/test": "^1.54.2",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'test/visual',
+  snapshotPathTemplate: '{testDir}/__screenshots__/{arg}-{projectName}{ext}',
+});

--- a/test/visual/__screenshots__/homepage-webkit.png
+++ b/test/visual/__screenshots__/homepage-webkit.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a451043b6fcd9e90a05a7d718270c683265d9c67ae46460169df126ccb04aac5
+size 5336

--- a/test/visual/example.spec.ts
+++ b/test/visual/example.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+// Build the app before running visual tests
+
+test.beforeAll(() => {
+  execSync('npm run build', {
+    stdio: 'inherit',
+    env: { ...process.env, SKIP_ICONS: '1' }
+  });
+});
+
+test('homepage has no visual regressions', async ({ page }) => {
+  const filePath = path.join(process.cwd(), 'dist', 'index.html');
+  await page.goto(`file://${filePath}`);
+  await expect(page).toHaveScreenshot('homepage.png');
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -54,6 +54,9 @@ export default defineConfig(({ base = '/' }) => ({
       name: 'generate-icons',
       apply: 'build',
       async buildStart() {
+        if (process.env.SKIP_ICONS) {
+          return;
+        }
         console.log('🔧 Generating icons...');
         await generateIcons();
       },


### PR DESCRIPTION
## Summary
- add Playwright for browser-based visual tests
- capture homepage screenshot and compare against baseline
- run visual tests in CI

## Testing
- `npm test`
- `npm run test:browser`


------
https://chatgpt.com/codex/tasks/task_e_6893ed263b74832286d32861aa3a301c